### PR TITLE
Update xstartup

### DIFF
--- a/templates/xstartup
+++ b/templates/xstartup
@@ -8,4 +8,4 @@
 
 vncconfig -iconic &
 
-dbus-launch --exit-with-session gnome-session &
+dbus-launch --exit-with-session {{ tigervnc_desktop_session }} &


### PR DESCRIPTION
Use tigervnc_desktop_session as the dbus-launch argument

---
name: Pull request
about: Modify the xstartup script

---

**Describe the change**
The xstartup script was not using the tigervnc_desktop_session variable.

